### PR TITLE
add automatic-updating

### DIFF
--- a/app/assets/javascripts/script.js
+++ b/app/assets/javascripts/script.js
@@ -1,5 +1,5 @@
 $(function(){
-  const poling_time = 5000;
+  const POLING_TIME = 5000;
 
   function append_member_list(id,name){
     let html = `
@@ -141,5 +141,5 @@ $(function(){
     }
   };
 
-  setInterval(reloadMessages,poling_time);
+  setInterval(reloadMessages,POLING_TIME);
 });

--- a/app/assets/javascripts/script.js
+++ b/app/assets/javascripts/script.js
@@ -1,4 +1,6 @@
 $(function(){
+  const poling_time = 5000;
+
   function append_member_list(id,name){
     let html = `
                 <div class='chat-group-user clearfix js-chat-member' id='chat-group-user-${id}'>
@@ -39,7 +41,7 @@ $(function(){
     let text = message.text ? `${message.text}` : "";
     let image = message.image.url ? `${message.image.url}` : "";
     let html = `
-                <li class="message-item">
+                <li class="message-item" data-message data-id="${message.id}">
                   <div class="message-item__upper">
                     <p class="message-item__upper__username">
                       ${message.user_name}
@@ -119,4 +121,25 @@ $(function(){
     let id_selector = $(this).parent().attr("id");
     remove_member_list(id_selector);
   });
+
+  var reloadMessages = function() {
+    if (window.location.href.match(/\/groups\/[0-9]+\/messages/)){
+      let last_message_id = $(".message-item").eq(-1).data("id");
+      $.ajax({
+        url: "./api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {message_id: last_message_id}
+      }).done(function(messages) {
+        messages.forEach(function(message){
+          append_message_list(message);
+        })
+        $(".main-center").animate({scrollTop: $(".message-list")[0].scrollHeight }, 'fast');
+      }).fail(function() {
+        alert('新規メッセージをロードできませんでした。');
+      });
+    }
+  };
+
+  setInterval(reloadMessages,poling_time);
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,13 +1,8 @@
 class Api::MessagesController < ApplicationController
   def index
-    @messages = Message.where("id > ?",message_params[:message_id])
+    @messages = Message.where("id > ?",params[:message_id])
     respond_to do |format|
       format.json
     end
   end
-
-  private
-    def message_params
-      params.permit(:message_id)
-    end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,13 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @messages = Message.where("id > ?",message_params[:message_id])
+    respond_to do |format|
+      format.json
+    end
+  end
+
+  private
+    def message_params
+      params.permit(:message_id)
+    end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.id message.id
+  json.text message.text
+  json.image message.image
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name message.user.name
+end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.id @message.id
-json.user_name @message.user.name
 json.text @message.text
 json.image @message.image
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.user_name @message.user.name

--- a/app/views/parts/_message-list.html.haml
+++ b/app/views/parts/_message-list.html.haml
@@ -1,6 +1,6 @@
 %ul.message-list
   - @messages.each do |message|
-    %li.message-item
+    %li.message-item{data: {id: message.id}}
       .message-item__upper
         %p.message-item__upper__username
           = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :show, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index,:create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
自動更新を実装した。
別のクライアントで更新があった際に、自動で更新して新しいメッセージを受信できるようになった。

# Why
クライアントが都度リロードをせずに済むようにするため

# 動作確認事項
・5秒毎にajax通信が発生していること。
・別のクライアントで更新があった際に、自動で更新して新しいメッセージを受信していること。
・複数一気に更新も可能であること。
・ログイン画面などで、エラーが発生していないこと。

# 画面キャプチャ
https://gyazo.com/5bb463e781de163e5ed20a971a25ecb8
